### PR TITLE
GatewayFilter in wrong scope based on README

### DIFF
--- a/lib/rubycas-client-rails.rb
+++ b/lib/rubycas-client-rails.rb
@@ -414,11 +414,11 @@ module RubyCAS
         return "#{Rails.root}/tmp/sessions/cas_sess.#{st}"
       end
     end
-    
-    class GatewayFilter < Filter
-      def self.use_gatewaying?
-        return true unless @@config[:use_gatewaying] == false
-      end
+  end
+
+  class GatewayFilter < Filter
+    def self.use_gatewaying?
+      return true unless @@config[:use_gatewaying] == false
     end
   end
 end


### PR DESCRIPTION
moved GatewayFilter out of Filter class to fix https://github.com/rubycas/rubycas-client-rails/issues/4
