### PR TITLE
Fix issue #17

### DIFF
--- a/lib/rubycas-client-rails.rb
+++ b/lib/rubycas-client-rails.rb
@@ -372,10 +372,8 @@ module RubyCAS
           log.debug("Using explicitly set service url: #{config[:service_url]}")
           return config[:service_url]
         end
-        
-        params = controller.params.dup
-        params.delete(:ticket)
-        service_url = controller.url_for(params)
+
+        service_url = controller.request.url
         log.debug("Guessed service url: #{service_url.inspect}")
         return service_url
       end


### PR DESCRIPTION
Simply use the request URL as the service URL. This handles the POST params case. It also handles cases of routes being created by an engine and routes with explicit subdomains.
