### PR TITLE
Fix for Rails 4.1.2 Missing Before

### DIFF
--- a/lib/rubycas-client-rails.rb
+++ b/lib/rubycas-client-rails.rb
@@ -20,6 +20,11 @@ module RubyCAS
     @@fake_extra_attributes = nil
     
     class << self
+
+      def before(controller)
+        self.filter controller
+      end
+
       def setup(config)
         @@config = config
         @@config[:logger] = Rails.logger unless @@config[:logger]


### PR DESCRIPTION
Fix for Rails 4.1.2 Missing before method
