### PR TITLE
Downgrade rubycas version

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -24,13 +24,20 @@ Now add both to your `Gemfile`:
 In your `application.rb` add:
 
     config.rubycas.cas_base_url = 'https://cas.example.com/'
-  
+    config.rubycas.session_store_klass = RubyCAS::RailsCacheStore
+
+Session Store Klass:
+
+There are two options, `RubyCAS::RailsCacheStore` and `RubyCAS::SessionStore`.  The default is SessionStore, but is not recommended because it causes a CookieOverflow issue.
+
+    config.rubycas.session_store_klass = RubyCAS::RailsCacheStore
+
 Finally, to enable the CAS filter for a controller:
 
     class MyController < ApplicationController
-  
+
       before_filter RubyCAS::Filter
-  
+
 Many other configuration options are available. For example you can instruct
 the client to log its actions to the default Rails logger using:
 

--- a/README.markdown
+++ b/README.markdown
@@ -20,6 +20,7 @@ Now add both to your `Gemfile`:
 
     gem 'rubycas-client'
     gem 'rubycas-client-rails', :path => '/path/where/you/cloned/rubycas-client-rails'
+    gem 'rubycas-client-rails', github: 'recruiting-tech/rubycas-client-rails', branch: 'ncsa-rails6'
 
 In your `application.rb` add:
 

--- a/lib/rubycas-client-rails.rb
+++ b/lib/rubycas-client-rails.rb
@@ -27,7 +27,7 @@ module RubyCAS
         @@log = @@client.log
       end
       
-      def filter(controller)
+      def before(controller)
         raise "Cannot use the CASClient filter because it has not yet been configured." if config.nil?
         
         if @@fake_user

--- a/lib/rubycas-client-rails.rb
+++ b/lib/rubycas-client-rails.rb
@@ -93,10 +93,6 @@ module RubyCAS
               # built around the old client.
               controller.session[:casfilteruser] = vr.user
               
-              if config[:enable_single_sign_out]
-                f = store_service_session_lookup(st, controller.request.session_options[:id] || controller.session.session_id)
-                log.debug("Wrote service session lookup file to #{f.inspect} with session id #{controller.request.session_options[:id] || controller.session.session_id.inspect}.")
-              end
             end
           
             # Store the ticket in the session to avoid re-validating the same service

--- a/lib/rubycas-client-rails.rb
+++ b/lib/rubycas-client-rails.rb
@@ -294,42 +294,6 @@ module RubyCAS
           end
           
           log.debug "Intercepted single-sign-out request for CAS session #{si.inspect}."
-
-          # Rails 2.3
-          ##required_sess_store = ActiveRecord::SessionStore
-          ##current_sess_store  = ActionController::Base.session_store
-
-          # Rails 2.2
-          ## required_sess_store = CGI::Session::ActiveRecordStore
-          ## current_sess_store  = ActionController::Base.session_options[:database_manager]
-
-          # Rails 3.0
-          required_sess_store = ActiveRecord::SessionStore
-          current_sess_store  = ::Rails.application.config.session_store
-
-          if current_sess_store == required_sess_store
-            session_id = read_service_session_lookup(si)
-
-            if session_id
-              session = current_sess_store::Session.find_by_session_id(session_id)
-              if session
-                st = session.data[:cas_last_valid_ticket] || si
-                delete_service_session_lookup(st) if st
-                session.destroy
-                log.debug("Destroyed #{session.inspect} for session #{session_id.inspect} corresponding to service ticket #{si.inspect}.")
-              else
-                log.debug("Data for session #{session_id.inspect} was not found. It may have already been cleared by a local CAS logout request.")
-              end
-              
-              log.info("Single-sign-out for session #{session_id.inspect} completed successfuly.")
-            else
-              log.warn("Couldn't destroy session with SessionIndex #{si} because no corresponding session id could be looked up.")
-            end
-          else
-            log.error "Cannot process logout request because this Rails application's session store is "+
-              " #{current_sess_store.name.inspect}. Single Sign-Out only works with the "+
-              " #{required_sess_store.name.inspect} session store."
-          end
           
           # Return true to indicate that a single-sign-out request was detected
           # and that further processing of the request is unnecessary.

--- a/lib/rubycas-client-rails.rb
+++ b/lib/rubycas-client-rails.rb
@@ -97,7 +97,7 @@ module RubyCAS
           
             # Store the ticket in the session to avoid re-validating the same service
             # ticket with the CAS server.
-            controller.session[:cas_last_valid_ticket] = st
+            controller.session[:cas_last_valid_ticket] = prepare_session_ticket(st)
             
             if vr.pgt_iou
               unless controller.session[:cas_pgt] && controller.session[:cas_pgt].ticket && controller.session[:cas_pgt].iou == vr.pgt_iou
@@ -271,6 +271,11 @@ module RubyCAS
       end
       
       private
+
+      def prepare_session_ticket(session_ticket)
+        session_ticket
+      end
+
       def single_sign_out(controller)
         
         # Avoid calling raw_post (which may consume the post body) if

--- a/lib/rubycas-client-rails.rb
+++ b/lib/rubycas-client-rails.rb
@@ -4,21 +4,21 @@ require 'casclient'
 module RubyCAS
   class Railtie < Rails::Railtie
     config.rubycas = ActiveSupport::OrderedOptions.new
-    
+
     initializer 'rubycas.initialize' do |app|
       RubyCAS::Filter.setup(config.rubycas)
     end
   end
-  
+
   class Filter
     cattr_reader :config, :log, :client
-    
+
     # These are initialized when you call setup.
     @@client = nil
     @@log = nil
     @@fake_user = nil
     @@fake_extra_attributes = nil
-    
+
     class << self
       def setup(config)
         @@config = config
@@ -26,40 +26,40 @@ module RubyCAS
         @@client = CASClient::Client.new(@@config)
         @@log = @@client.log
       end
-      
+
       def before(controller)
         raise "Cannot use the CASClient filter because it has not yet been configured." if config.nil?
-        
+
         if @@fake_user
           controller.session[client.username_session_key] = @@fake_user
           controller.session[:casfilteruser] = @@fake_user
           controller.session[client.extra_attributes_session_key] = @@fake_extra_attributes
           return true
         end
-        
-        
+
+
         last_st = controller.session[:cas_last_valid_ticket]
-        
+
         if single_sign_out(controller)
-          controller.send(:render, :text => "CAS Single-Sign-Out request intercepted.")
-          return false 
+          controller.send(:render, :plain => "CAS Single-Sign-Out request intercepted.")
+          return false
         end
 
         st = read_ticket(controller)
-        
+
         is_new_session = true
-        
-        if st && last_st && 
-            last_st.ticket == st.ticket && 
+
+        if st && last_st &&
+            last_st.ticket == st.ticket &&
             last_st.service == st.service
-          # warn() rather than info() because we really shouldn't be re-validating the same ticket. 
-          # The only situation where this is acceptable is if the user manually does a refresh and 
+          # warn() rather than info() because we really shouldn't be re-validating the same ticket.
+          # The only situation where this is acceptable is if the user manually does a refresh and
           # the same ticket happens to be in the URL.
           log.warn("Re-using previously validated ticket since the ticket id and service are the same.")
           st = last_st
           is_new_session = false
         elsif last_st &&
-            !config[:authenticate_on_every_request] && 
+            !config[:authenticate_on_every_request] &&
             controller.session[client.username_session_key]
           # Re-use the previous ticket if the user already has a local CAS session (i.e. if they were already
           # previously authenticated for this service). This is to prevent redirection to the CAS server on every
@@ -73,32 +73,32 @@ module RubyCAS
           st = last_st
           is_new_session = false
         end
-        
+
         if st
           client.validate_service_ticket(st) unless st.has_been_validated?
           vr = st.response
-          
+
           if st.is_valid?
             if is_new_session
               log.info("Ticket #{st.ticket.inspect} for service #{st.service.inspect} belonging to user #{vr.user.inspect} is VALID.")
               controller.session[client.username_session_key] = vr.user.dup
               controller.session[client.extra_attributes_session_key] = HashWithIndifferentAccess.new(vr.extra_attributes) if vr.extra_attributes
-              
+
               if vr.extra_attributes
                 log.debug("Extra user attributes provided along with ticket #{st.ticket.inspect}: #{vr.extra_attributes.inspect}.")
               end
-              
+
               # RubyCAS-Client 1.x used :casfilteruser as it's username session key,
               # so we need to set this here to ensure compatibility with configurations
               # built around the old client.
               controller.session[:casfilteruser] = vr.user
-              
+
             end
-          
+
             # Store the ticket in the session to avoid re-validating the same service
             # ticket with the CAS server.
             controller.session[:cas_last_valid_ticket] = prepare_session_ticket(st)
-            
+
             if vr.pgt_iou
               unless controller.session[:cas_pgt] && controller.session[:cas_pgt].ticket && controller.session[:cas_pgt].iou == vr.pgt_iou
                 log.info("Receipt has a proxy-granting ticket IOU. Attempting to retrieve the proxy-granting ticket...")
@@ -117,7 +117,7 @@ module RubyCAS
               end
 
             end
-            
+
             return true
           else
             log.warn("Ticket #{st.ticket.inspect} failed validation -- #{vr.failure_code}: #{vr.failure_message}")
@@ -139,7 +139,7 @@ module RubyCAS
               log.warn "The CAS client is NOT configured to allow gatewaying, yet this request was gatewayed. Something is not right!"
             end
           end
-          
+
           unauthorized!(controller)
           return false
         end
@@ -148,10 +148,10 @@ module RubyCAS
         unauthorized!(controller)
         return false
       end
-      
+
       # used to allow faking for testing
       # with cucumber and other tools.
-      # use like 
+      # use like
       #  CASClient::Frameworks::Rails::Filter.fake("homer")
       # you can also fake extra attributes by including a second parameter
       #  CASClient::Frameworks::Rails::Filter.fake("homer", {:roles => ['dad', 'husband']})
@@ -159,14 +159,14 @@ module RubyCAS
         @@fake_user = username
         @@fake_extra_attributes = extra_attributes
       end
-      
+
       def use_gatewaying?
         @@config[:use_gatewaying]
       end
-      
-      # Returns the login URL for the current controller. 
+
+      # Returns the login URL for the current controller.
       # Useful when you want to provide a "Login" link in a GatewayFilter'ed
-      # action. 
+      # action.
       def login_url(controller)
         service_url = read_service_url(controller)
         url = client.add_service_to_login_url(service_url)
@@ -176,7 +176,7 @@ module RubyCAS
 
       # allow controllers to reuse the existing config to auto-login to
       # the service
-      # 
+      #
       # Use this from within a controller. Pass the controller, the
       # login-credentials and the path that you want the user
       # resdirected to on success.
@@ -205,20 +205,20 @@ module RubyCAS
         else
           log.info("Ticket #{resp.ticket.inspect} for service #{return_path.inspect} is VALID.")
         end
-        
+
         resp
       end
-      
-      # Clears the given controller's local Rails session, does some local 
+
+      # Clears the given controller's local Rails session, does some local
       # CAS cleanup, and redirects to the CAS logout page. Additionally, the
-      # <tt>request.referer</tt> value from the <tt>controller</tt> instance 
-      # is passed to the CAS server as a 'destination' parameter. This 
+      # <tt>request.referer</tt> value from the <tt>controller</tt> instance
+      # is passed to the CAS server as a 'destination' parameter. This
       # allows RubyCAS server to provide a follow-up login page allowing
-      # the user to log back in to the service they just logged out from 
-      # using a different username and password. Other CAS server 
-      # implemenations may use this 'destination' parameter in different 
-      # ways. 
-      # If given, the optional <tt>service</tt> URL overrides 
+      # the user to log back in to the service they just logged out from
+      # using a different username and password. Other CAS server
+      # implemenations may use this 'destination' parameter in different
+      # ways.
+      # If given, the optional <tt>service</tt> URL overrides
       # <tt>request.referer</tt>.
       def logout(controller, service = nil)
         referer = service || controller.request.referer
@@ -227,7 +227,7 @@ module RubyCAS
         controller.send(:reset_session)
         controller.send(:redirect_to, client.logout_url(referer))
       end
-      
+
       def unauthorized!(controller, vr = nil)
         if controller.params[:format] == "xml"
           if vr
@@ -239,37 +239,37 @@ module RubyCAS
           redirect_to_cas_for_authentication(controller)
         end
       end
-      
+
       def redirect_to_cas_for_authentication(controller)
         redirect_url = login_url(controller)
-        
+
         if use_gatewaying?
           controller.session[:cas_sent_to_gateway] = true
           redirect_url << "&gateway=true"
         else
           controller.session[:cas_sent_to_gateway] = false
         end
-        
+
         if controller.session[:previous_redirect_to_cas] &&
             controller.session[:previous_redirect_to_cas] > (Time.now - 1.second)
           log.warn("Previous redirect to the CAS server was less than a second ago. The client at #{controller.request.remote_ip.inspect} may be stuck in a redirection loop!")
           controller.session[:cas_validation_retry_count] ||= 0
-          
+
           if controller.session[:cas_validation_retry_count] > 3
             log.error("Redirection loop intercepted. Client at #{controller.request.remote_ip.inspect} will be redirected back to login page and forced to renew authentication.")
             redirect_url += "&renew=1&redirection_loop_intercepted=1"
           end
-          
+
           controller.session[:cas_validation_retry_count] += 1
         else
           controller.session[:cas_validation_retry_count] = 0
         end
         controller.session[:previous_redirect_to_cas] = Time.now
-        
+
         log.debug("Redirecting to #{redirect_url.inspect}")
         controller.send(:redirect_to, redirect_url)
       end
-      
+
       private
 
       def prepare_session_ticket(session_ticket)
@@ -277,14 +277,14 @@ module RubyCAS
       end
 
       def single_sign_out(controller)
-        
+
         # Avoid calling raw_post (which may consume the post body) if
         # this seems to be a file upload
         if content_type = controller.request.headers["CONTENT_TYPE"] &&
             content_type =~ %r{^multipart/}
           return false
         end
-        
+
         if controller.request.post? &&
             controller.params['logoutRequest'] &&
             controller.params['logoutRequest'] =~
@@ -292,60 +292,60 @@ module RubyCAS
           # TODO: Maybe check that the request came from the registered CAS server? Although this might be
           #       pointless since it's easily spoofable...
           si = $~[1]
-          
+
           unless config[:enable_single_sign_out]
             log.warn "Ignoring single-sign-out request for CAS session #{si.inspect} because ssout functionality is not enabled (see the :enable_single_sign_out config option)."
             return false
           end
-          
+
           log.debug "Intercepted single-sign-out request for CAS session #{si.inspect}."
-          
+
           # Return true to indicate that a single-sign-out request was detected
           # and that further processing of the request is unnecessary.
           return true
         end
-        
+
         # This is not a single-sign-out request.
         return false
       end
-      
+
       def read_ticket(controller)
-        # Note that we are now deleting the 'ticket' and 'renew' parameters, since they really 
+        # Note that we are now deleting the 'ticket' and 'renew' parameters, since they really
         # have no business getting passed on to the controller action.
-        
+
         ticket = controller.params.delete(:ticket)
-        
+
         return nil unless ticket
-        
+
         log.debug("Request contains ticket #{ticket.inspect}.")
-        
+
         if ticket =~ /^PT-/
           CASClient::ProxyTicket.new(ticket, read_service_url(controller), controller.params.delete(:renew))
         else
           CASClient::ServiceTicket.new(ticket, read_service_url(controller), controller.params.delete(:renew))
         end
       end
-      
+
       def returning_from_gateway?(controller)
         controller.session[:cas_sent_to_gateway]
       end
-      
+
       def read_service_url(controller)
         if config[:service_url]
           log.debug("Using explicitly set service url: #{config[:service_url]}")
           return config[:service_url]
         end
-        
+
         params = controller.params.dup
         params.delete(:ticket)
         service_url = controller.url_for(params)
         log.debug("Guessed service url: #{service_url.inspect}")
         return service_url
       end
-      
+
       # Creates a file in tmp/sessions linking a SessionTicket
       # with the local Rails session id. The file is named
-      # cas_sess.<session ticket> and its text contents is the corresponding 
+      # cas_sess.<session ticket> and its text contents is the corresponding
       # Rails session id.
       # Returns the filename of the lookup file created.
       def store_service_session_lookup(st, sid)
@@ -355,17 +355,17 @@ module RubyCAS
         f.close
         return f.path
       end
-      
+
       # Returns the local Rails session ID corresponding to the given
       # ServiceTicket. This is done by reading the contents of the
-      # cas_sess.<session ticket> file created in a prior call to 
+      # cas_sess.<session ticket> file created in a prior call to
       # #store_service_session_lookup.
       def read_service_session_lookup(st)
         st = st.ticket if st.kind_of? CASClient::ServiceTicket
         ssl_filename = filename_of_service_session_lookup(st)
         return File.exists?(ssl_filename) && IO.read(ssl_filename)
       end
-      
+
       # Removes a stored relationship between a ServiceTicket and a local
       # Rails session id. This should be called when the session is being
       # closed.
@@ -376,14 +376,14 @@ module RubyCAS
         ssl_filename = filename_of_service_session_lookup(st)
         File.delete(ssl_filename) if File.exists?(ssl_filename)
       end
-      
+
       # Returns the path and filename of the service session lookup file.
       def filename_of_service_session_lookup(st)
         st = st.ticket if st.kind_of? CASClient::ServiceTicket
         return "#{Rails.root}/tmp/sessions/cas_sess.#{st}"
       end
     end
-    
+
     class GatewayFilter < Filter
       def self.use_gatewaying?
         return true unless @@config[:use_gatewaying] == false

--- a/rubycas-client-rails.gemspec
+++ b/rubycas-client-rails.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = %q{rubycas-client-rails}
-  s.version = "0.1.0"
+  s.version = "0.2.0"
 
   s.authors = ["Matt Zukowski"]
   s.date = %q{2011-08-13}

--- a/rubycas-client-rails.gemspec
+++ b/rubycas-client-rails.gemspec
@@ -4,6 +4,7 @@ Gem::Specification.new do |s|
 
   s.authors = ["Matt Zukowski"]
   s.date = %q{2011-08-13}
+  s.summary = %q{RubyCAS-Client Railtie for Rails 3.0.}
   s.description = %q{Rails plugin for using the RubyCAS-Client as a controller filter.}
   s.email = %q{matt dot zukowski at utoronto dot ca}
   s.files = `git ls-files`.split("\n")

--- a/rubycas-client-rails.gemspec
+++ b/rubycas-client-rails.gemspec
@@ -13,5 +13,5 @@ Gem::Specification.new do |s|
   s.rubyforge_project = %q{rubycas-client}
 
   s.add_dependency('rails', '>= 3.0.0')
-  s.add_dependency('rubycas-client', '>= 2.2.0')
+  s.add_dependency('rubycas-client', '2.2.1')
 end

--- a/rubycas-client-rails.gemspec
+++ b/rubycas-client-rails.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = %q{rubycas-client-rails}
-  s.version = "0.2.0"
+  s.version = "0.2.1"
 
   s.authors = ["Matt Zukowski"]
   s.date = %q{2011-08-13}
@@ -15,5 +15,5 @@ Gem::Specification.new do |s|
   s.rubyforge_project = %q{rubycas-client}
 
   s.add_dependency('rails', '>= 3.0.0')
-  s.add_dependency('rubycas-client', '~> 2.3.9.rc1')
+  s.add_dependency('rubycas-client', '2.2.1')
 end


### PR DESCRIPTION
master branch had the upgraded version, but that client does not have the response object.  Following https://github.com/nzpost/rubycas-client-rails/commit/dc88982ad938e8fdf48f7df62c3a082a550b7e93 for a version that works with this.